### PR TITLE
:bug: Fixed cw and ccw not equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ultimate Toroidal Propeller Generator
 
-![version](https://badgen.net/badge/version/v1.0.0?icon=github)
+![version](https://badgen.net/badge/version/v1.0.1?icon=github)
 ![license](https://badgen.net/github/license/RaulBejarano/Ultimate-Toroidal-Propeller-Generator)
 ![commits](https://badgen.net/github/commits//RaulBejarano/Ultimate-Toroidal-Propeller-Generator/main)
 

--- a/src/toroidal_propeller.scad
+++ b/src/toroidal_propeller.scad
@@ -27,7 +27,8 @@ module toroidal_propeller(
                         );
                         
                         // Substract what is inside other blades
-                        rotate([0,0,-360/blades])
+                        cw_ccw_mult = blade_twist > 0 ? -1 : 1;
+                        rotate([0,0, cw_ccw_mult * 360/blades])
                             linear_extrude(height=height, twist=blade_twist)
                                 translate([blade_length/2,0,0])
                                     resize([blade_length, blade_width]) circle(d=blade_length);


### PR DESCRIPTION
Fixed #1 by taking in account the direction (CW or CCW) of the propeller by checking if twitst is positive or negative.