### PR TITLE
Added airflow direction parameter and updated the notch logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ toroidal_propeller(
     blade_attack_angle = 35,        // blade attack angle | Default(35)
     blade_offset = -6,              // blade distance from propeller axis | Default(-6)
     blade_safe_direction = "PREV",  // indicates if a blade must delete itself from getting into the previous (PREV) or the next blade (NEXT) | Default("PREV")
-    hub_height = 6,                 // Hub height | Default(6)
+    hub_height = 6,                 // hub height | Default(6)
     hub_d = 16,                     // hub diameter | Default(16)
     hub_screw_d = 5.5,              // hub screw diameter | Default(5.5)
-    hub_notch_height = 0,           // height for the notch | Default(0 = [No support])
-    hub_notch_d = 0                 // diameter for the notch | Default(0 = [No support])
+    hub_notch_height = 0,           // bottom closure/notch height | Default(0 = none)
+    hub_notch_d = 0,                // bottom notch diameter (any size; 0 closes bottom by height) | Default(0)
+    flow_direction = "SUCK"         // airflow: "SUCK" or "BLOW" | Default("SUCK")
 );
 ```
 
@@ -67,12 +68,13 @@ toroidal_propeller(
 - `blade_hole_offset`: displacement between outer and inner sides of the blades. It shouldn't be greater than thickness.
 - `blade_attack_angle`: this sets how is going to be the attack angle. A positive value will generate a CW propeller and a negative one a CCW.
 - `blade_offset`: blade distance from propeller axis
-- `safe_blades_direction`: indicates if a blade must delete itself from getting into the previous or the next blade.
+- `blade_safe_direction`: indicates if a blade must delete itself from getting into the previous or the next blade.
 - `hub_height`: hub or holder height.
 - `hub_d`: hub or holder diameter.
 - `hub_screw_d`: motor axis screw diameter.
-- `hub_notch_height`: support hole height.
-- `hub_notch_d`: support hole diameter.
+- `hub_notch_height`: bottom closure/notch height. When `hub_notch_d = 0`, this closes the screw hole from the bottom by this height.
+- `hub_notch_d`: bottom notch diameter. Can be any size (including between 0 and `hub_screw_d`). If 0, only the bottom is closed by `hub_notch_height`.
+- `flow_direction`: airflow direction, either `"SUCK"` or `"BLOW"`. Affects twist direction and handedness.
 
 That's all! Render it with this values with OpenSCAD and you will get something similar to this:
 

--- a/example.scad
+++ b/example.scad
@@ -14,7 +14,7 @@ toroidal_propeller(
     hub_height = 6,                 // Hub height | Default(6)
     hub_d = 16,                     // hub diameter | Default(16)
     hub_screw_d = 5.5,              // hub screw diameter | Default(5.5)
-    hub_notch_height = 0,           // height for the notch | Default(0 = [No support])
-    hub_notch_d = 0,                // diameter for the notch | Default(0 = [No support])
+    hub_notch_height = 0,           // bottom closure/notch height | Default(0 = none)
+    hub_notch_d = 0,                // bottom notch diameter (0 closes bottom by height) | Default(0)
     flow_direction = "SUCK"         // airflow: "SUCK" or "BLOW" | Default("SUCK")
 );

--- a/example.scad
+++ b/example.scad
@@ -15,5 +15,6 @@ toroidal_propeller(
     hub_d = 16,                     // hub diameter | Default(16)
     hub_screw_d = 5.5,              // hub screw diameter | Default(5.5)
     hub_notch_height = 0,           // height for the notch | Default(0 = [No support])
-    hub_notch_d = 0                 // diameter for the notch | Default(0 = [No support])
+    hub_notch_d = 0,                // diameter for the notch | Default(0 = [No support])
+    flow_direction = "SUCK"         // airflow: "SUCK" or "BLOW" | Default("SUCK")
 );

--- a/src/toroidal_propeller.scad
+++ b/src/toroidal_propeller.scad
@@ -25,6 +25,9 @@ module toroidal_propeller(
         flow_direction == "SUCK" ?  1 :
         flow_direction == "BLOW" ? -1 : 1;
 
+    notch_h = (hub_notch_height > 0) ? min(hub_notch_height, hub_height) : 0;
+    screw_top_h = hub_height - notch_h;
+
     difference(){
         union(){
             linear_extrude(height=height, twist=flow_mult * (l/p) * 360, convexity=2){
@@ -46,10 +49,15 @@ module toroidal_propeller(
 
             cylinder(d = hub_d, h = hub_height);
         }
-        translate([0,0,-eps]){
-            cylinder(d = hub_screw_d, h = hub_height + 2*eps);
-            cylinder(d = hub_notch_d, h = hub_notch_height + eps);
-        }
+
+
+        if (screw_top_h > 0)
+            translate([0,0, notch_h - eps])
+                cylinder(d = hub_screw_d, h = screw_top_h + 2*eps);
+
+        if (hub_notch_d > 0 && notch_h > 0)
+            translate([0,0,-eps])
+                cylinder(d = hub_notch_d, h = notch_h + 2*eps);
     }
 }
 


### PR DESCRIPTION
# Description

The airflow direction parameter have been added because I didn't read the docs and didn't know that `blade_attack_angle*-1` achieves the same thing and I wanted to use the project to generate a desk fan propeller. The parameter is optional so adding it won't be a breaking change and might make it easier for someone lazy to use the project without googling what CW and CCW propellers are. The notch changes add an option to transform the notch into a closure which is more aesthetically pleasing.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I rendered a propeller in OpenSCAD and it worked.

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

# Breaking Changes Warning

As the logic of how the `hub_notch_*` variables are handled changed projects which used `hub_notch_heigth > 0` and `hub_notch_d == 0` at the same time will need to be updated.